### PR TITLE
Fix warning for localhost when squid >= 3.2

### DIFF
--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -14,7 +14,7 @@ auth_param basic credentialsttl <%= node['squid']['ldap_authcredentialsttl'] %>
 
 <%= "acl all src" if node['squid']['version'].to_i < 3 %>
 <%= "acl manager proto cache_object" if node['squid']['version'].to_f < 3.2 %>
-acl localhost src 127.0.0.1/32
+<%= "acl localhost src 127.0.0.1/32" if node['squid']['version'].to_f < 3.2 %>
 <%= "acl to_localhost dst 127.0.0.0/8 0.0.0.0/32" if node['squid']['version'].to_f < 3.2 %>
 acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
 acl localnet src 172.16.0.0/12	# RFC1918 possible internal network


### PR DESCRIPTION
This prevent squid to emit warning during logrotate in ubuntu 14.04.