### PR TITLE
template fixes

### DIFF
--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -83,12 +83,11 @@ refresh_pattern     (Release|Package(.gz)*)$	0	20%	2880
 # refresh_pattern	    \.$			1440    20%	10080
 # refresh_pattern	    .				0	20%	4320
 hosts_file /etc/hosts
+maximum_object_size <%= node['squid']['max_obj_size'] %> <%= node['squid']['max_obj_size_unit'] %>
 <%- if node['squid']['enable_cache_dir'] %>
 cache_dir ufs <%= node['squid']['cache_dir'] %> <%= node['squid']['cache_size'] %> 16 256
 <%- end %>
 coredump_dir <%= node['squid']['coredump_dir'] %>
-refresh_pattern deb$ 1577846 100% 1577846
-maximum_object_size <%= node['squid']['max_obj_size'] %> <%= node['squid']['max_obj_size_unit'] %>
 cache_mem <%= node['squid']['cache_mem'] %> MB
 <% @directives.each do |directive| %>
 <%= directive %>


### PR DESCRIPTION
- maximum_object_size directive needs to be specified before cache_dir directive, otherwise squid will ignore it
- removed stray refresh_pattern